### PR TITLE
Add try output option

### DIFF
--- a/combine/README.md
+++ b/combine/README.md
@@ -33,3 +33,4 @@ python combine.py path/to/config.txt
 ```
 
 The script saves the combined output in `./combined-files` by default. Use `-o` to specify a different directory.
+Add `-t`/`--try-output` to preview the combined content without creating a file.


### PR DESCRIPTION
## Summary
- allow previewing combined file without saving with `--try-output`
- document the `-t/--try-output` option

## Testing
- `python combine/combine.py -h`
- `python combine/combine.py combine/example.conf -t`
- `python combine/combine.py combine/example.conf -o tmpdir`

------
https://chatgpt.com/codex/tasks/task_e_686996f7bd5c8329ad6cbb1d1e37d94f